### PR TITLE
Update/newfold UI component library

### DIFF
--- a/tests/cypress/integration/ctb.cy.js
+++ b/tests/cypress/integration/ctb.cy.js
@@ -32,7 +32,7 @@ describe('Click to buy', function () {
 			.scrollIntoView()
 			.should('exist')
 			.should('be.visible');
-		cy.get('.yst-button--primary[data-action="load-nfd-ctb"]')
+		cy.get('.nfd-button--primary[data-action="load-nfd-ctb"]')
 			.should('have.attr', 'data-ctb-id')
 			.and('equal', '57d6a568-783c-45e2-a388-847cff155897');
 	});


### PR DESCRIPTION
Fixes failing tests found in https://github.com/bluehost/bluehost-wordpress-plugin/pull/624

Ideally, we're not using these classes in tests, but for now, we can just update them and hopefully overhaul tests to be better.