### PR TITLE
Fix route URL double slashes

### DIFF
--- a/includes/assets/ctb.js
+++ b/includes/assets/ctb.js
@@ -4,7 +4,7 @@
 		let ctbId = e.target.getAttribute('data-ctb-id');
 		e.target.closest('.ctb-actions').innerHTML = '<div class="ctb-loader"></div>';
 		window.fetch(
-			`${ window.NewfoldRuntime.restUrl }/newfold-ctb/v1/ctb/${ ctbId }`,
+			`${ window.NewfoldRuntime.restUrl }newfold-ctb/v1/ctb/${ ctbId }`,
 			{
 				credentials: 'same-origin',
 				method: 'POST',
@@ -34,7 +34,7 @@
 		let modal = openModal(e, ctbId);
 		let modalWindow = modal.querySelector('.ctb-modal-content');
 		window.fetch(
-			`${ window.NewfoldRuntime.restUrl }/newfold-ctb/v1/ctb/${ ctbId }`,
+			`${ window.NewfoldRuntime.restUrl }newfold-ctb/v1/ctb/${ ctbId }`,
 			{
 				credentials: 'same-origin',
 				headers: {
@@ -88,10 +88,10 @@
 		document.querySelector('body').classList.add('noscroll');
 
 		purchaseStatus = false;
-		
+
 		return ctbContainer;
 	}
-	
+
 	const closeModal = (e) => {
 		ctbmodal.destroy();
 		document.querySelector('body').classList.remove('noscroll');
@@ -113,7 +113,7 @@
 		if (notice) {
 			notice.parentNode.removeChild(notice);
 			window.fetch(
-				`${ window.NewfoldRuntime.restUrl }/newfold-notifications/v1/notifications/${ notice.dataset.id }`,
+				`${ window.NewfoldRuntime.restUrl }newfold-notifications/v1/notifications/${ notice.dataset.id }`,
 				{
 					credentials: 'same-origin',
 					method: 'DELETE',
@@ -143,7 +143,7 @@
 		() => {
 			document.getElementById('wpwrap').addEventListener('click', function(event) {
 				if (event.target.dataset.action === 'load-nfd-ctb') {
-					if ( 
+					if (
 						! supportsGlobalCTB() && // can NOT access global ctb
 						window.nfdctb.supportsCTB // but does support legacy ctb
 					) { // has token and customer id


### PR DESCRIPTION
[The Runtime module uses `rest_url()`](https://github.com/newfold-labs/wp-module-runtime/blob/trunk/includes/Runtime.php#L58) to determine the base url for the rest route. This uses [`get_rest_url()`](https://github.com/WordPress/wordpress-develop/blob/6.3/src/wp-includes/rest-api.php#L457-L516) which already appends a `/` by default. 

So we are currently double slashing the path in the URL, which is leading to 404s for any of these requests. 