### PR TITLE
Update test again

### DIFF
--- a/tests/cypress/integration/ctb.cy.js
+++ b/tests/cypress/integration/ctb.cy.js
@@ -7,13 +7,14 @@ describe('Click to buy', function () {
 
 	before(() => {
 		cy.exec( 'npx wp-env run cli wp transient delete newfold_marketplace' );
+		cy.visit( '/wp-admin/index.php' );
 		cy.intercept({
 			method: 'GET',
 			url: /newfold-marketplace(\/|%2F)v1(\/|%2F)marketplace/
 		}, ctbProductsFixture ).as( 'ctbProductsFixture' );
 
 		cy.visit('/wp-admin/admin.php?page=' + Cypress.env('pluginId') + '#/marketplace', {
-			onBeforeLoad() {
+			onLoad() {
 				cy.window().then((win) => {
 					win.nfdctb.supportsCTB = true;
 					win.NewfoldRuntime.capabilities.canAccessGlobalCTB = false;


### PR DESCRIPTION
Clear app by visiting admin home before tests.
Use onLoad rather than onBeforeLoad to set the supportsCTB value.

This fixes flaky issues locally at least.